### PR TITLE
DEVOPS-2826: Add kustomize tests and/or precommit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: kustomize
+  name: kustomize
+  description: Run kustomize build on all directories containing kustomization
+  minimum_pre_commit_version: 2.1.0
+  entry: ./kustomize/validate-kustomize
+  args: []
+  language: script

--- a/kustomize/validate-kustomize
+++ b/kustomize/validate-kustomize
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+KUSTOMIZE_DIRS=$(find . -type f -name '*kustomization.yaml' | sed -E 's|/[^/]+$||' |sort -u )
+COLOR_GREEN="\x1b[32;01m"
+COLOR_YELLOW="\x1b[33;01m"
+COLOR_RED="\x1b[31;01m"
+COLOR_RESET="\x1b[39;49;00m"
+
+FAILED=0
+IFS=$'\n'
+echo "test: kustomize build"
+for item in $KUSTOMIZE_DIRS
+do
+  echo -e $COLOR_YELLOW"[START] kustomize build $item"$COLOR_RESET
+  time kustomize build $item && echo -e $COLOR_GREEN"[PASS] kustomize build $item"$COLOR_RESET || echo -e $COLOR_RED"[FAILED] kustomize build $item"$COLOR_RESET && FAILED=1
+done
+
+exit $FAILED


### PR DESCRIPTION
**Description**

Precommit hooks for kustomize aren&#39;t working in the lint stage in github because it runs inside a docker container. It also means that the checks are slow.
```
#  - repo: https://github.com/dmitri-lerko/pre-commit-docker-kustomize #    rev: f3a8533
#    hooks:
#      - id: kustomize
#        name: deployments-cluster-services
#        args: \[deployments/cluster-services\]
#        verbose: false
```
Fixes [#DEVOPS-2826](https://team-turo.atlassian.net//browse/DEVOPS-2826)

**Changes**

* feat(kustomize): adds kustomize pre-commit hook

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
