### PR TITLE
fix: make gomarkdoc be able to pull repo setting from Action env

### DIFF
--- a/hooks/golang/gomarkdoc.sh
+++ b/hooks/golang/gomarkdoc.sh
@@ -4,5 +4,17 @@
 #
 set -e
 
-output="$(gomarkdoc --output '{{.Dir}}/README.md' ./...)"
+# Provide a default for this because it's easier than a check/replace
+GITHUB_SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+# We switch behavior if we're running on GitHub Actions because we can't
+# autodetect the GitHub remote URI correctly
+if [ -n "$GITHUB_REPOSITORY" ]; then
+    # Trim trailing slash if it's present
+    GITHUB_REPOSITORY="${GITHUB_REPOSITORY%%/}"
+    # Build the CLI arg for manually setting the repo
+    REPOSITORY="--repository.url ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+fi
+
+# shellcheck disable=SC2086
+output="$(gomarkdoc --output '{{.Dir}}/README.md' $REPOSITORY ./...)"
 [ -z "$output" ]


### PR DESCRIPTION
- Was incorrectly detecting repo URI and rewriting the docs without internal links
- Makes it detect Actions by the presence of the default environment variables
