### PR TITLE
fix(golang): remove deadcode checker

### DIFF
--- a/hooks/golang/golangci-lint.sh
+++ b/hooks/golang/golangci-lint.sh
@@ -8,7 +8,6 @@ lint_all () {
         --out-format colored-line-number \
         --color always \
         --enable asciicheck \
-        --enable deadcode \
         --enable durationcheck \
         --enable errcheck \
         --enable exportloopref \


### PR DESCRIPTION
The `deadcode` checker is buggy and doesn't respect exporting as a valid use of code. So it should go bye bye.

See also: https://github.com/golangci/golangci-lint/issues/1841