### PR TITLE
feat(hooks): ignore node_modules in hooks using go list ./...

### DIFF
--- a/hooks/golang/go-build.sh
+++ b/hooks/golang/go-build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-FILES=$(go list ./...  | grep -v /vendor/)
+FILES=$(go list ./...  | grep -v -e /vendor/ -e /node_modules/))
 exec go build $FILES

--- a/hooks/golang/go-test-unit.sh
+++ b/hooks/golang/go-test-unit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-FILES=$(go list ./...  | grep -v /vendor/)
+FILES=$(go list ./...  | grep -v -e /vendor/ -e /node_modules/)
 
 # We don't use build tags commonly enough, so we're just going to run all tests
 # locally and let the tests use environment flags to run integration tests.


### PR DESCRIPTION

**Description**


For now I added it to the grep filter. I think cases like this are going to be limited. Eventually if
the list grows too much, we can think of a better process.


**Changes**

* feat(hooks): ignore node_modules in hooks using 'go list ./...'

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
