### PR TITLE
DEVOPS-6474: added pre-commit hook for terraform resource sorting

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -93,3 +93,12 @@
   entry: hooks/yaml/yaml-extension.sh
   language: script
   files: \.yml$
+######################
+# Terraform related hooks
+# These only have shell dependencies
+- id: tf-sort
+  name: "Ensure tf file is alphabetically sorted"
+  description: "Outputs an alphabetically sorted Terraform file"
+  entry: hooks/terraform/tf-sort.sh
+  language: script
+  files: \.tf$

--- a/README.md
+++ b/README.md
@@ -93,8 +93,15 @@ The following hooks are available:
 **Docker**
 
 - **docker-lint** (_requires docker_) - Runs hadolint on Dockerfiles
-- **docker-compose-lint** (_requires docker_) - Runs docker-compose config on
-compose files
+- **docker-compose-lint** (_requires docker_) - Runs docker-compose config on compose files
+
+**YAML**
+
+- **yaml-extension** - Verifies that yaml files have the right extension
+
+**Terraform**
+
+- **tf-sort** - Ensures tf file resources are alphabetically sorted (ascending a-z)
 
 ### Example
 

--- a/hooks/terraform/tf-sort.sh
+++ b/hooks/terraform/tf-sort.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Verifies that terraform file resources are alphabetically sorted
+set -e
+
+# shellcheck disable=SC2016
+awk_command='
+#!/usr/bin/env -S awk -f
+# https://gist.github.com/yermulnik/7e0cf991962680d406692e1db1b551e6
+# Tested with GNU Awk 5.0.1, API: 2.0 (GNU MPFR 4.0.2, GNU MP 6.2.0)
+# Usage: cat variables.tf | awk -f /path/to/tf_vars_sort.awk | tee sorted_variables.tf
+# No licensing; yermulnik@gmail.com, 2021-2022
+{
+	# skip blank lines at the beginning of file
+	if (!resource_type && length($0) == 0) next
+
+	# pick only known Terraform resource definition block names of the 1st level
+	# https://github.com/hashicorp/terraform/blob/main/internal/configs/parser_config.go#L55-L163
+	switch ($0) {
+		case /^[[:space:]]*(locals|moved|terraform)[[:space:]]+{/:
+			resource_type = $1
+			resource_ident = resource_type "|" block_counter++
+		case /^[[:space:]]*(data|resource)[[:space:]]+("?[[:alnum:]_-]+"?[[:space:]]+){2}{/:
+			resource_type = $1
+			resource_subtype = $2
+			resource_name = $3
+			resource_ident = resource_type "|" resource_subtype "|" resource_name
+		case /^[[:space:]]*(module|output|provider|variable)[[:space:]]+"?[[:alnum:]_-]+"?[[:space:]]+{/:
+			resource_type = $1
+			resource_name = $2
+			resource_ident = resource_type "|" resource_name
+	}
+	arr[resource_ident] = arr[resource_ident] ? arr[resource_ident] RS $0 : $0
+} END {
+	# exit if there was solely empty input
+	# (input consisting of multiple empty lines only, counts in as empty input too)
+	if (length(arr) == 0) exit
+	# declare empty array (the one to hold final result)
+	split("", res)
+	# case-insensitive string operations in this block
+	# (primarily for the `asort()` call below)
+	IGNORECASE = 1
+	# sort by `resource_ident` which is a key in our case
+	asort(arr)
+
+	# blank-lines-fix each block
+	for (item in arr) {
+		split(arr[item],new_arr,RS)
+
+		# remove multiple blank lines at the end of resource definition block
+		while (length(new_arr[length(new_arr)]) == 0) delete new_arr[length(new_arr)]
+
+		# add one single blank line at the end of the resource definition block
+		# so that blocks are delimited with a blank like to align with TF code style
+		new_arr[length(new_arr)+1] = RS
+
+		# fill resulting array with data from each resource definition block
+		for (line in new_arr) {
+			# trim whitespaces at the end of each line in resource definition block
+			gsub(/[[:space:]]+$/, "", new_arr[line])
+			res[length(res)+1] = new_arr[line]
+		}
+	}
+
+	# ensure there are no extra blank lines at the beginning and end of data
+	while (length(res[1]) == 0) delete res[1]
+	while (length(res[length(res)]) == 0) delete res[length(res)]
+
+	# print resulting data to stdout
+	for (line in res) {
+		print res[line]
+	}
+}
+'
+
+check_files() {
+    has_error=0
+    for file in "$@" ; do
+      tf=$(cat "$file")
+      sorted_tf=$(awk "$awk_command" "$file")
+      # if files are different
+      if ! diff  <(echo "$tf" ) <(echo "$sorted_tf")  > /dev/null 2>&1 ; then
+        echo "ERROR: $file was not correctly sorted"
+        has_error=1
+        # write to the file
+        echo "$sorted_tf" > "$file"
+      fi
+
+
+    done
+    return $has_error
+}
+if ! check_files "$@" ; then
+    echo "Some terraform files failed"
+fi
+
+exit $has_error


### PR DESCRIPTION

**Description**

Since some of our Terrraform files are very lengthy, we want to keep their resources alphabetically sorted (ex: [https://github.com/turo/tf-github/blob/main/src/repos.platform.tf](https://github.com/turo/tf-github/blob/main/src/repos.platform.tf))

Currently we don’t enforce this with a pre-commit hook and is often forgotten and (maybe) seen in a PR code review.

Fixes [#DEVOPS-6474](https://team-turo.atlassian.net/browse/DEVOPS-6474)

**Changes**

* feat: added tf-sort hook to be able to alphabetically sort resources in a HCL file

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
