### PR TITLE
[Golang] Enable allow-parallel-runners for golanci-lint

### DIFF
--- a/hooks/golang/golangci-lint-common.sh
+++ b/hooks/golang/golangci-lint-common.sh
@@ -3,6 +3,7 @@
 # We're using a large subset in addition to the defaults
 lint_all() {
   golangci-lint run \
+    --allow-parallel-runners \
     --fix \
     --verbose \
     --out-format colored-line-number \


### PR DESCRIPTION
## Changes
- When linting, we should actually run `--allow-parallel-runners` by default. (If we didn't, each repo should add their own `.golangci.yaml` which you can find more information here: https://golangci-lint.run/usage/configuration/

I believe this should fix some issues where the `golangci-lint` is being used as a prehook, and we thought we enabled `allow-parallel-runners` but its not actually being used
