### PR TITLE
fix: use custom script instead of depending on yalc

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -94,7 +94,7 @@
   language: script
   files: \.yml$
   ######################
-# Yalc related hook - requires yalc to run
+# Yalc related hook
 - id: yalc-check
   name: "Ensure no yalc dependencies are staged"
   description: "Errors if there are staged yalc dependencies"

--- a/hooks/yalc/yalc-check.sh
+++ b/hooks/yalc/yalc-check.sh
@@ -2,4 +2,8 @@
 # Exits with status code 1 if a yalc dependency is present in the package manifest
 set -e
 
-yalc check
+for file in "$@" ; do
+    if egrep "(file|link):\.yalc" $file; then
+        exit 1
+    fi
+done

--- a/hooks/yalc/yalc-check.sh
+++ b/hooks/yalc/yalc-check.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
-# Exits with status code 1 if a yalc dependency is present in the package manifest
+# Verifies no yalc dependency is present
 set -e
 
-for file in "$@" ; do
-    if egrep "(file|link):\.yalc" $file; then
-        exit 1
-    fi
-done
+check_files() {
+    has_error=0
+    for file in "$@" ; do
+        if egrep "(file|link):\.yalc" $file; then
+            echo "ERROR: $file should not have a yalc dependency"
+            has_error=1
+        fi
+    done
+}
+
+check_files "$@"
+exit $has_error


### PR DESCRIPTION
I realized that we would need to install `yalc` in CI environment because we are running `pre-commit` on all files in github actions. This accomplishes the same check without depending on `yalc`.