### PR TITLE
fix: force go-test-unit to be non-parallel

### DIFF
--- a/hooks/golang/go-test-unit.sh
+++ b/hooks/golang/go-test-unit.sh
@@ -4,7 +4,8 @@ FILES=$(go list ./...  | grep -v -e /vendor/ -e /node_modules/)
 # We don't use build tags commonly enough, so we're just going to run all tests
 # locally and let the tests use environment flags to run integration tests.
 # go test -tags=unit -timeout 30s -short -v ${FILES}
-go test -timeout 30s -short -v ${FILES}
+# shellcheck disable=SC2086
+go test -parallel 1 -timeout 30s -short -v ${FILES}
 
 returncode=$?
 if [ $returncode -ne 0 ]; then


### PR DESCRIPTION
- Passing multiple files triggered parallel tests which caused individual tests to fail in race condition