### PR TITLE
feat: remove all but current default golang linters

### DIFF
--- a/hooks/golang/golangci-lint-common.sh
+++ b/hooks/golang/golangci-lint-common.sh
@@ -8,38 +8,12 @@ lint_all() {
     --verbose \
     --out-format colored-line-number \
     --color always \
-    --enable asciicheck \
-    --enable deadcode \
-    --enable durationcheck \
     --enable errcheck \
-    --enable exportloopref \
-    --enable gci \
-    --enable gocognit \
-    --enable goconst \
-    --enable gocritic \
-    --enable gocyclo \
-    --enable gofmt \
-    --enable gofumpt \
-    --enable goimports \
-    --enable gosec \
     --enable gosimple \
     --enable govet \
-    --enable ifshort \
     --enable ineffassign \
-    --enable prealloc \
-    --enable predeclared \
-    --enable sqlclosecheck \
     --enable staticcheck \
-    --enable structcheck \
-    --enable tagliatelle \
-    --enable typecheck \
-    --enable unconvert \
-    --enable unparam \
     --enable unused \
-    --enable varcheck \
-    --enable wastedassign \
-    --enable whitespace \
-    --enable wrapcheck \
     ./...
   return $?
 }


### PR DESCRIPTION
Remove all but the current golang linters that are enabled by default as noted [here](https://golangci-lint.run/usage/linters/).

This to hopefully eliminate golang linter errors in our Lint job (in many terraform module repositories) that cause an error of the form "ERRO [linters_context] gocritic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt: setting an explicit GOROOT can fix this problem." to be reported at Lint time.