### PR TITLE
fix: allow golangci lint timeout to vary

### DIFF
--- a/hooks/golang/golangci-lint-common.sh
+++ b/hooks/golang/golangci-lint-common.sh
@@ -14,6 +14,7 @@ lint_all() {
     --enable ineffassign \
     --enable staticcheck \
     --enable unused \
+    --timeout 2m \
     ./...
   return $?
 }


### PR DESCRIPTION
See if increasing timeout actually allows golangci-lint to pass the loading stage.