### PR TITLE
fix: increase golangci hook timeout to 5 minutes

### DIFF
--- a/hooks/golang/golangci-lint-common.sh
+++ b/hooks/golang/golangci-lint-common.sh
@@ -14,7 +14,7 @@ lint_all() {
     --enable ineffassign \
     --enable staticcheck \
     --enable unused \
-    --timeout 2m \
+    --timeout 5m \
     ./...
   return $?
 }


### PR DESCRIPTION
Increase the timeout to 5 minutes from 2 minutes, per @shakefu suggestion.