### PR TITLE
test: attempt to constrain golangci-lint memory use

### DIFF
--- a/hooks/golang/golangci-lint-common.sh
+++ b/hooks/golang/golangci-lint-common.sh
@@ -2,7 +2,7 @@
 # There's a ton of available linters: https://golangci-lint.run/usage/linters
 # We're using a large subset in addition to the defaults
 lint_all() {
-  golangci-lint run \
+  GOGC=5 GOMEMLIMIT=1GiB golangci-lint run \
     --allow-parallel-runners \
     --fix \
     --verbose \


### PR DESCRIPTION
Attempt to constrain `golangci-lint` memory use via various means.