### PR TITLE
DEVOPS-9767: Use regular semantic-release for turo pre-commit-hooks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,17 +2,32 @@ name: CI
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  workflow_dispatch:
 
 jobs:
+
+  release-notes:
+    name: Release notes preview
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - uses: open-turo/actions-release/release-notes-preview@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          NPM_TOKEN: ${{ secrets.OPEN_TURO_NPM_TOKEN }}
+
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: pre-commit/action@v2.0.0
-      - uses: wagoid/commitlint-github-action@v2
+      - uses: open-turo/action-pre-commit@v1
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo no tests
+        shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,10 +8,13 @@ on:
 # Handle release versioning automatically with semantic release
 jobs:
   semantic-release:
-    name: Semantic Release
+    name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: go-semantic-release/action@v1
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: open-turo/actions-release/semantic-release@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-plugins: |
+            @open-turo/semantic-release-config


### PR DESCRIPTION

**Description**

Use open-turo actions for releases and linting

Fixes [#DEVOPS-9767](https://team-turo.atlassian.net//browse/DEVOPS-9767)

**Changes**

* ci: update release and ci workflow to latest standards

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
