### PR TITLE
fix: have golangci-lint report its version

### DIFF
--- a/hooks/golang/golangci-lint-common.sh
+++ b/hooks/golang/golangci-lint-common.sh
@@ -2,6 +2,10 @@
 # There's a ton of available linters: https://golangci-lint.run/usage/linters
 # We're using a large subset in addition to the defaults
 lint_all() {
+  ## Lets first report what version of golangi-lint is being run since it will
+  ## not otherwise provide that information.
+  golangci-lint --version
+
   golangci-lint run \
     --allow-parallel-runners \
     --fix \


### PR DESCRIPTION
Lets demand that `golangci-lint` report its version before it runs for troubleshooting purposes.