### PR TITLE
SPIKE test `cspell` integration with pre-commit-hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -95,3 +95,11 @@
   language: script
   entry: hooks/yalc/yalc-check.sh
   files: package\.json
+######################
+# Spell checking related hooks
+- id: cspell
+  name: "(TODO add name) Check spelling"
+  description: "(TODO add description) Check spelling"
+  language: script
+  entry: hooks/cspell/cspell.sh
+        

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -98,8 +98,8 @@
 ######################
 # Spell checking related hooks
 - id: cspell
-  name: "(TODO add name) Check spelling"
-  description: "(TODO add description) Check spelling"
+  name: "Check for spelling errors with `cspell-cli`"
+  description: "Find and report spelling errors in staged files"
   language: script
   entry: hooks/cspell/cspell.sh
-        
+

--- a/hooks/cspell/cspell.sh
+++ b/hooks/cspell/cspell.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+echo "helloworld"

--- a/hooks/cspell/cspell.sh
+++ b/hooks/cspell/cspell.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
 set -e
 
-has_error=0
-
-echo "helloworld"
-
-exit $has_error
+git diff --name-only | npx cspell --no-summary --no-progress --no-must-find-files --file-list stdin

--- a/hooks/cspell/cspell.sh
+++ b/hooks/cspell/cspell.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 echo "helloworld"

--- a/hooks/cspell/cspell.sh
+++ b/hooks/cspell/cspell.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 set -e
 
+has_error=0
+
 echo "helloworld"
+
+exit $has_error


### PR DESCRIPTION
The purpose of this PR is to exemplify the possible solution for adding spell checking to the Turo dev workflow via `pre-commit-hooks`

The PR is a draft additional to the [Automate spell checking in WEB pull requests RFC](https://team-turo.atlassian.net/wiki/spaces/EN/pages/2822570230/RFC-251+Automate+spell+checking+in+WEB+pull+requests+WIP) to get more feedback from the team.


### Screenshots:

Below is an example of how the output would look. There is an extra amount of words here, displaying a bunch of false positives such as "Turo". The output should be greatly trimmed upon adding a dictionary.

 
![Screenshot 2024-01-12 at 3 36 33 PM](https://github.com/turo/pre-commit-hooks/assets/115834167/9e7e7bfe-00ed-44ca-b5b9-12a0ec879c2f)
