### PR TITLE
feat: sort top-level nodes of YAML files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -87,6 +87,12 @@
   entry: hooks/yaml/yaml-extension.sh
   language: script
   files: \.yml$
+- id: yaml-sort
+  name: "yaml-sort: Style formatting"
+  description: "Ensure top-level nodes are sorted in YAML files"
+  entry: hooks/yaml/yaml-sort.sh
+  language: script
+  files: \.yaml$
   ######################
 # Yalc related hook
 - id: yalc-check

--- a/hooks/yaml/yaml-sort.sh
+++ b/hooks/yaml/yaml-sort.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+yaml_file="$1"
+
+main() {
+    if [[ ! -f "$yaml_file" ]]; then
+        echo "Error: $yaml_file not found"
+        exit 1
+    fi
+    if ! command -v yq &> /dev/null; then
+        echo "Error: yq is required but not installed"
+        echo "Install with: brew install yq"
+        exit 1
+    fi
+
+    temp_file=$(mktemp)
+
+    yq eval 'sort_keys(.)' "$yaml_file" > "$temp_file"
+
+    if [[ $? -eq 0 ]]; then
+        mv "$temp_file" "$yaml_file"
+        echo "Sorted top-level keys in $yaml_file."
+        git add "$yaml_file"
+        exit 0
+    else
+        echo "Error: Failed to sort YAML file"
+        rm -f "$temp_file"
+        exit 1
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
This hook replaces [this script](https://github.com/turo/analytics-event-schema/blob/main/script/sort-events) so it can be reused also in https://github.com/turo/deep-link-schema.